### PR TITLE
Work around coverage limitation on Windows

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,20 +2,50 @@
 
 [tox]
 envlist =
-  py36
+  coverage-erase
+  pytest
+  behave
+  coverage-report
 
-[testenv]
+[testenv:coverage-erase]
+basepython = python3.6
+deps =
+  coverage
+skip_install = True
+commands =
+  coverage erase
+
+[testenv:pytest]
+basepython = python3.6
 deps =
   -rrequirements.txt
+setenv =
+  COVERAGE_FILE=.coverage.{envname}
 commands =
   flake8 \
     src/cli/ \
-    features/environment.py \
-    features/steps/ \
     tests/
-  coverage erase
+  coverage run -m pytest tests/
+
+[testenv:behave]
+basepython = python3.6
+deps =
+  -rrequirements.txt
+setenv =
+  COVERAGE_FILE=.coverage.{envname}
+commands =
+  flake8 \
+    features/environment.py \
+    features/steps/
   coverage run -a -m behave
-  coverage run -a -m pytest tests/
+
+[testenv:coverage-report]
+basepython = python3.6
+deps =
+  coverage
+skip_install = True
+commands =
+  coverage combine
   coverage html
   coverage report -m --fail-under=100
 


### PR DESCRIPTION
By forcing the use of `coverage combine`, we seem to be able to
leverage the `[paths]` section in `.coveragerc` to convince coverage
that the paths are actually equivalent.